### PR TITLE
Filter todos by status

### DIFF
--- a/client/cypress/integration/todos-list.spec.ts
+++ b/client/cypress/integration/todos-list.spec.ts
@@ -33,6 +33,19 @@ describe('Todos list', () => {
     );
   });
 
+  it('Should select a status and get results', () => {
+    // Filter for status 'viewer');
+    page.selectStatus('complete');
+
+    // Some of the todos should be listed
+    page.getTodosCards().should('have.lengthOf.above', 0);
+
+    // All of the todo card items that show should have the status we are looking for
+    page.getTodosCards().each(el => {
+      cy.wrap(el).find('.todo-card-status').should('contain', 'true');
+    });
+  });
+
   it('Should change the view', () => {
     // Choose the view type "List"
     page.changeView('list');

--- a/client/cypress/integration/todos-list.spec.ts
+++ b/client/cypress/integration/todos-list.spec.ts
@@ -41,8 +41,8 @@ describe('Todos list', () => {
     page.getTodosCards().should('have.lengthOf.above', 0);
 
     // All of the todo card items that show should have the status we are looking for
-    page.getTodosCards().each(el => {
-      cy.wrap(el).find('.todo-card-status').should('contain', 'true');
+    page.getTodosCards().find('.todos-card-status').each($card => {
+      cy.wrap($card).should('have.text', 'true');
     });
   });
 

--- a/client/src/app/todos/todos-list.component.html
+++ b/client/src/app/todos/todos-list.component.html
@@ -16,6 +16,20 @@
           </mat-form-field>
         </div>
 
+        <div fxLayout="row wrap" fxLayoutGap="10px">
+          <!-- Examples of filtering on the server -->
+
+          <mat-form-field class="input-field">
+            <mat-label>Status</mat-label>
+            <mat-select (selectionChange)="getTodosFromServer()" [(ngModel)]="todosStatus" data-test="todosStatusSelect">
+              <mat-option>--</mat-option>
+              <mat-option value="complete">True</mat-option>
+              <mat-option value="incomplete">False</mat-option>
+            </mat-select>
+            <mat-hint>Filtered on server</mat-hint>
+          </mat-form-field>
+        </div>
+
         <br>
         <div fxLayout="row wrap" fxLayoutGap="10px">
           <label>View type: </label>

--- a/client/src/app/todos/todos-list.component.ts
+++ b/client/src/app/todos/todos-list.component.ts
@@ -1,11 +1,10 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { Todos } from './todos';
 import { TodosService } from './todos.service';
 import { Subscription } from 'rxjs';
 
 @Component({
-  selector: 'app-todos-list',
+  selector: 'app-todos-list-component',
   templateUrl: './todos-list.component.html',
   styleUrls: ['./todos-list.component.scss'],
   providers: []
@@ -35,7 +34,9 @@ export class TodosListComponent implements OnInit, OnDestroy {
 
   getTodosFromServer() {
     this.unsub();
-    this.getTodosSub = this.todosService.getTodos().subscribe(returnedTodos => {
+    this.getTodosSub = this.todosService.getTodos({
+      status: this.todosStatus
+    }).subscribe(returnedTodos => {
       this.serverFilteredTodos = returnedTodos;
       this.updateFilter();
     }, err => {

--- a/client/src/app/todos/todos.service.spec.ts
+++ b/client/src/app/todos/todos.service.spec.ts
@@ -104,6 +104,26 @@ describe('TodosService', () => {
     });
   });
 
+  it('getTodos() calls api/todos with filter parameter \'status\'', () => {
+
+    todosService.getTodos({ status: "complete" }).subscribe(
+      todos => expect(todos).toBe(testTodos)
+    );
+
+    // Specify that (exactly) one request will be made to the specified URL with the role parameter.
+    const req = httpTestingController.expectOne(
+      (request) => request.url.startsWith(todosService.todosUrl) && request.params.has('status')
+    );
+
+    // Check that the request made to that URL was a GET request.
+    expect(req.request.method).toEqual('GET');
+
+    // Check that the role parameter was 'admin'
+    expect(req.request.params.get('status')).toEqual('complete');
+
+    req.flush(testTodos);
+  });
+
   describe('filterTodos()', () => {
     /*
      * Since `filterTodos` actually filters "locally" (in

--- a/client/src/app/todos/todos.service.spec.ts
+++ b/client/src/app/todos/todos.service.spec.ts
@@ -106,7 +106,7 @@ describe('TodosService', () => {
 
   it('getTodos() calls api/todos with filter parameter \'status\'', () => {
 
-    todosService.getTodos({ status: "complete" }).subscribe(
+    todosService.getTodos({ status: 'complete' }).subscribe(
       todos => expect(todos).toBe(testTodos)
     );
 
@@ -118,7 +118,6 @@ describe('TodosService', () => {
     // Check that the request made to that URL was a GET request.
     expect(req.request.method).toEqual('GET');
 
-    // Check that the role parameter was 'admin'
     expect(req.request.params.get('status')).toEqual('complete');
 
     req.flush(testTodos);

--- a/client/src/app/todos/todos.service.ts
+++ b/client/src/app/todos/todos.service.ts
@@ -16,8 +16,15 @@ export class TodosService {
 
 
 
-  getTodos(): Observable<Todos[]> {
-    const httpParams: HttpParams = new HttpParams();
+  getTodos(filters?: { status?: string }): Observable<Todos[]> {
+    let httpParams: HttpParams = new HttpParams();
+
+    if (filters){
+      if (filters.status) {
+        httpParams = httpParams.set('status', filters.status);
+      }
+  }
+
 
     return this.httpClient.get<Todos[]>(this.todosUrl, {
       params: httpParams,

--- a/server/src/main/java/umm3601/todo/TodoController.java
+++ b/server/src/main/java/umm3601/todo/TodoController.java
@@ -29,7 +29,7 @@ import io.javalin.http.NotFoundResponse;
  */
 public class TodoController {
 
-  private static final String OWNER_KEY = "owner";
+  private static final String STATUS_KEY = "status";
 
   private final JacksonMongoCollection<Todo> todoCollection;
 
@@ -72,6 +72,16 @@ public class TodoController {
 
     List<Bson> filters = new ArrayList<>(); // start with a blank document
 
+    if (ctx.queryParamMap().containsKey(STATUS_KEY)) {
+      Boolean status;
+      if ("complete".equals((ctx.queryParam(STATUS_KEY)))){
+        status = true;
+      }
+      else{
+        status = false;
+      }
+      filters.add(eq(STATUS_KEY, status));
+  }
     ctx.json(todoCollection.find(filters.isEmpty() ? new Document() : and(filters))
       .into(new ArrayList<>()));
   }

--- a/server/src/test/java/umm3601/todo/TodoControllerSpec.java
+++ b/server/src/test/java/umm3601/todo/TodoControllerSpec.java
@@ -137,6 +137,49 @@ public class TodoControllerSpec {
     assertEquals(db.getCollection("todos").countDocuments(), JavalinJson.fromJson(result, Todo[].class).length);
   }
 
+  @Test
+  public void GetTodosByStatus() throws IOException {
+
+    // Set the query string to test with
+    mockReq.setQueryString("status=complete");
+
+    // Create our fake Javalin context
+    Context ctx = ContextUtil.init(mockReq, mockRes, "api/todos");
+
+    TodoController.getTodos(ctx);
+
+    assertEquals(200, mockRes.getStatus()); // The response status should be 200
+
+    String result = ctx.resultString();
+    Todo[] resultTodos = JavalinJson.fromJson(result, Todo[].class);
+
+    assertEquals(3, resultTodos.length); // There should be two todos returned
+    for (Todo todo : resultTodos) {
+      assertEquals(true, todo.status); // Every todo should be true
+    }
+  }
+
+  @Test
+  public void GetTodosByStatusFalse() throws IOException {
+
+    // Set the query string to test with
+    mockReq.setQueryString("status=incomplete");
+
+    // Create our fake Javalin context
+    Context ctx = ContextUtil.init(mockReq, mockRes, "api/todos");
+
+    TodoController.getTodos(ctx);
+
+    assertEquals(200, mockRes.getStatus()); // The response status should be 200
+
+    String result = ctx.resultString();
+    Todo[] resultTodos = JavalinJson.fromJson(result, Todo[].class);
+
+    assertEquals(1, resultTodos.length); // There should be one todos returned
+    for (Todo todo : resultTodos) {
+      assertEquals(false, todo.status); // Every todo should be false
+    }
+  }
 
   @Test
   public void GetTodoWithExistentId() throws IOException {


### PR DESCRIPTION
These methods make it possible to filter todos by status using the server. Also added is the ability for the client to request those filtered todos from the server so the user can see them in the webpage. Co-authored by Kyle Day <day00090@morris.umn.edu>