### PR TITLE
Filter todos by body using the client

### DIFF
--- a/client/cypress/integration/todos-list.spec.ts
+++ b/client/cypress/integration/todos-list.spec.ts
@@ -33,6 +33,21 @@ describe('Todos list', () => {
     );
   });
 
+  it('Should type something in the body filter and check that it returned correct elements', () => {
+    // Filter for todos 'sunt'
+    cy.get('#todos-body-input').type('sunt');
+
+    // All of the todos cards should have the owner we are filtering by
+    page.getTodosCards().each(e => {
+      cy.wrap(e).find('.todos-card-body').should('have.text', 'sunt');
+    });
+
+    // (We check this two ways to show multiple ways to check this)
+    page.getTodosCards().find('.todos-card-body').each($el =>
+      expect($el.text()).to.equal('sunt')
+    );
+  });
+
   it('Should select a status and get results', () => {
     // Filter for status 'viewer');
     page.selectStatus('complete');

--- a/client/cypress/integration/todos-list.spec.ts
+++ b/client/cypress/integration/todos-list.spec.ts
@@ -37,14 +37,10 @@ describe('Todos list', () => {
     // Filter for todos 'sunt'
     cy.get('#todos-body-input').type('sunt');
 
-    // All of the todos cards should have the owner we are filtering by
-    page.getTodosCards().each(e => {
-      cy.wrap(e).find('.todos-card-body').should('have.text', 'sunt');
-    });
-
+    // All of the todos cards should have the body we are filtering by
     // (We check this two ways to show multiple ways to check this)
     page.getTodosCards().find('.todos-card-body').each($el =>
-      expect($el.text()).to.equal('sunt')
+      expect($el.text()).to.contain('sunt')
     );
   });
 

--- a/client/src/app/todos/todos-list.component.html
+++ b/client/src/app/todos/todos-list.component.html
@@ -14,6 +14,13 @@
             [(ngModel)]="todosOwner" (input)="updateFilter()">
             <mat-hint>Filtered on client</mat-hint>
           </mat-form-field>
+
+          <mat-form-field class="input-field">
+            <mat-label>Body</mat-label>
+            <input matInput id="todos-body-input" placeholder="Filter by body"
+            [(ngModel)]="todosBody" (input)="updateFilter()">
+            <mat-hint>Filtered on client</mat-hint>
+          </mat-form-field>
         </div>
 
         <div fxLayout="row wrap" fxLayoutGap="10px">

--- a/client/src/app/todos/todos-list.component.ts
+++ b/client/src/app/todos/todos-list.component.ts
@@ -45,7 +45,7 @@ export class TodosListComponent implements OnInit, OnDestroy {
   }
   public updateFilter() {
     this.filteredTodos = this.todosService.filterTodos(
-      this.serverFilteredTodos, { owner: this.todosOwner });
+      this.serverFilteredTodos, { owner: this.todosOwner, body: this.todosBody});
   }
 
   /**

--- a/client/src/app/todos/todos.service.spec.ts
+++ b/client/src/app/todos/todos.service.spec.ts
@@ -147,12 +147,12 @@ describe('TodosService', () => {
     it('filters by body', () => {
       const todosBody = 'to';
       const filteredTodos = todosService.filterTodos(testTodos, { body: todosBody });
-      // There should be two todos with an 'i' in their
-      // owner: Chris and Jamie.
+      // There should be two todos with an 'sunt' in their
+      // body: Chris and Pam.
       expect(filteredTodos.length).toBe(2);
-      // Every returned todos owner should contain an 'i'.
+      // Every returned todos body should contain 'sunt'.
       filteredTodos.forEach(todos => {
-        expect(todos.owner.indexOf(todosBody)).toBeGreaterThanOrEqual(0);
+        expect(todos.body.indexOf(todosBody)).toBeGreaterThanOrEqual(0);
       });
     });
   });

--- a/client/src/app/todos/todos.service.spec.ts
+++ b/client/src/app/todos/todos.service.spec.ts
@@ -143,6 +143,18 @@ describe('TodosService', () => {
         expect(todos.owner.indexOf(todosName)).toBeGreaterThanOrEqual(0);
       });
     });
+
+    it('filters by body', () => {
+      const todosBody = 'to';
+      const filteredTodos = todosService.filterTodos(testTodos, { body: todosBody });
+      // There should be two todos with an 'i' in their
+      // owner: Chris and Jamie.
+      expect(filteredTodos.length).toBe(2);
+      // Every returned todos owner should contain an 'i'.
+      filteredTodos.forEach(todos => {
+        expect(todos.owner.indexOf(todosBody)).toBeGreaterThanOrEqual(0);
+      });
+    });
   });
  });
 });

--- a/client/src/app/todos/todos.service.ts
+++ b/client/src/app/todos/todos.service.ts
@@ -35,7 +35,7 @@ export class TodosService {
     return this.httpClient.get<Todos>(this.todosUrl + '/' + id);
   }
 
-  filterTodos(todos: Todos[], filters: { owner?: string }): Todos[] {
+  filterTodos(todos: Todos[], filters: { body?: string; owner?: string }): Todos[] {
 
     let filteredTodos = todos;
 
@@ -44,6 +44,13 @@ export class TodosService {
       filters.owner = filters.owner.toLowerCase();
 
       filteredTodos = filteredTodos.filter(todo => todo.owner.toLowerCase().indexOf(filters.owner) !== -1);
+    }
+
+    // Filter by body
+    if (filters.body) {
+      filters.body = filters.body;
+
+      filteredTodos = filteredTodos.filter(todo => todo.body.indexOf(filters.body) !== -1);
     }
     return filteredTodos;
   }


### PR DESCRIPTION
These methods filter the todos by their bodies containing certain text all tests have full coverage. Co-authored by Kyle Day <day00090@morris.umn.edu>